### PR TITLE
添加默认cookie

### DIFF
--- a/bilireq/utils/__init__.py
+++ b/bilireq/utils/__init__.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from hashlib import md5
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode
@@ -18,6 +19,7 @@ DEFAULT_HEADERS = {
         " Safari/537.36 Edg/87.0.664.60"
     ),
     "Referer": "https://www.bilibili.com/",
+    "cookie":f'buvid3={uuid.uuid4()}',
 }
 APPKEY = "4409e2ce8ffd12b8"
 APPSEC = "59b43e04ad6965f34319062b478f83dd"


### PR DESCRIPTION
现在，即使在未登录的情况下访问B站主站也会有set-cookie
如果不带cookie直接访问接口则会被判定为爬虫进而返回"错误码-401 非法访问"

目前发现只需在cookie里带上“buvid3”参数即可解决,该参数可以固定(如:"0"),也可以通过uuid自己生成

如果后续B站进一步严格对访问cookie的限制也可以在初始化的时候先访问一次B站主站,将set-cookie的内容存下来再进行对其它接口的访问